### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setuptools.setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@
 # <http://www.gnu.org/licenses/>.
 
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 skip_missing_interpreters = true
 minversion = 3.13.2
 requires =
@@ -34,6 +34,7 @@ python =
     3.6: py36
     3.7: py37
     3.8: lint-check, py38
+    3.9: py39
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 [tox]
 envlist = py36,py37,py38,py39
 skip_missing_interpreters = true
-minversion = 3.13.2
+minversion = 3.20.1
 requires =
     setuptools >= 44.0.0
     wheel >= 0.34.2


### PR DESCRIPTION
Python 3.9 is now released, so we might as well support it now to avoid future porting headaches. It is expected that actual deployments will be almost entirely focal using Python 3.8 for at least the next 2 years.