### PR TITLE
Fix upload section of tox.ini for pypi uploads

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,12 +61,13 @@ commands =
     twine check {distdir}/ops-lib-pgsql-*.zip
     black --check .
 
-
 [testenv:upload]
 basepython = python3
 sitepackages = false
 skip_install = false
-whitelist = ls gpg bash
+whitelist_externals =
+    ls
+    bash
 deps =
     setuptools
     wheel
@@ -75,7 +76,7 @@ commands =
     python setup.py bdist_wheel --universal --dist-dir {distdir}
     bash -c 'for f in {distdir}/*.{zip,whl}; do gpg --detach-sign -a $f; done'
     ls -al {distdir}
-    twine upload --verbose --skip-existing {distdir}/*pgsql-*.{zip,whl,asc}
+    bash -c 'twine upload --verbose --skip-existing {distdir}/*pgsql-*.{zip,whl,asc}'
 
 [testenv]
 sitepackages = false


### PR DESCRIPTION
It is busted, at least with the newer version of tox we need for Python 3.9. Fix it.